### PR TITLE
Fix log purger

### DIFF
--- a/.github/workflows/logging-service.yml
+++ b/.github/workflows/logging-service.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET Core
+    - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
+        dotnet-version: 6.0.x
     - name: Create Build Directories
       run: |
         mkdir -p ./Build/NuGet/Cache

--- a/Services/Logging/TixFactory.Logging.Service/Controllers/LoggingController.cs
+++ b/Services/Logging/TixFactory.Logging.Service/Controllers/LoggingController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using TixFactory.Http.Service;
 
 namespace TixFactory.Logging.Service.Controllers
 {
@@ -46,15 +47,15 @@ namespace TixFactory.Logging.Service.Controllers
 		}
 
 		[HttpDelete]
-		public async Task<IActionResult> Purge(int months, CancellationToken cancellationToken)
+		public async Task<Payload<int>> Purge(int months, CancellationToken cancellationToken)
 		{
 			if (months < 1)
 			{
 				throw new ArgumentException($"{nameof(months)} must be at least 1.", nameof(months));
 			}
 
-			await _ElasticLogger.PurgeAsync(DateTime.UtcNow - TimeSpan.FromDays(30 * months), cancellationToken).ConfigureAwait(false);
-			return new NoContentResult();
+			var count = await _ElasticLogger.PurgeAsync(DateTime.UtcNow - TimeSpan.FromDays(30 * months), cancellationToken).ConfigureAwait(false);
+			return new Payload<int>(count, null);
 		}
 	}
 }

--- a/Services/Logging/TixFactory.Logging.Service/Dockerfile
+++ b/Services/Logging/TixFactory.Logging.Service/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/core/aspnet:6.0
 
 # Copies the contents of the directory the Dockerfile is in into the image.
 COPY ./Application /Application

--- a/Services/Logging/TixFactory.Logging.Service/Dockerfile
+++ b/Services/Logging/TixFactory.Logging.Service/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 
 # Copies the contents of the directory the Dockerfile is in into the image.
 COPY ./Application /Application

--- a/Services/Logging/TixFactory.Logging.Service/Interfaces/IElasticLogger.cs
+++ b/Services/Logging/TixFactory.Logging.Service/Interfaces/IElasticLogger.cs
@@ -8,6 +8,6 @@ namespace TixFactory.Logging.Service
 	{
 		Task LogAsync(LogRequest logRequest, CancellationToken cancellationToken);
 
-		Task PurgeAsync(DateTime clearBefore, CancellationToken cancellationToken);
+		Task<int> PurgeAsync(DateTime clearBefore, CancellationToken cancellationToken);
 	}
 }

--- a/Services/Logging/TixFactory.Logging.Service/TixFactory.Logging.Service.csproj
+++ b/Services/Logging/TixFactory.Logging.Service/TixFactory.Logging.Service.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TixFactoryVersion>2.0.154</TixFactoryVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
# What

Disk space got full, and the logs couldn't be deleted.

```json
{
	"error": {
		"root_cause": [
			{
				"type": "cluster_block_exception",
				"reason": "index [tix-factory] blocked by: [TOO_MANY_REQUESTS/12/disk usage exceeded flood-stage watermark, index has read-only-allow-delete block];"
			}
		],
		"type": "cluster_block_exception",
		"reason": "index [tix-factory] blocked by: [TOO_MANY_REQUESTS/12/disk usage exceeded flood-stage watermark, index has read-only-allow-delete block];"
	},
	"status": 429
}
```

# Solution

Per-[stackoverflow](https://stackoverflow.com/a/58008464/1663648):

```bash
curl -XPUT -H "Content-Type: application/json" http://localhost:9200/_all/_settings -d '{"index.blocks.read_only_allow_delete": null}'
```